### PR TITLE
adding repo source link to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ life_cycle: 'pre-alpha' # FIXME
 license: 'CC-BY 4.0'
 
 # Link to the source repository for this lesson
-source: 'https://github.com/carpentries/workbench-template-md' # FIXME
+source: 'https://github.com/kerchner/lc-open-reproducible-research-cloud'
 
 # Default branch of your lesson
 branch: 'main'


### PR DESCRIPTION
The source link in the config makes sure the links, like 'edit on github', go to the right GH repo.